### PR TITLE
Adjust opacity, Add Windowrule(Youtube no longer translucent)

### DIFF
--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -121,7 +121,7 @@ decoration {
     # https://wiki.hypr.land/Configuring/Variables/#blur
     blur {
         enabled = true
-        size = 3
+        size = 8
         passes = 1
 
         vibrancy = 0.1696
@@ -290,7 +290,7 @@ bindl = , XF86AudioPrev, exec, playerctl previous
 
 # Example windowrule
 # windowrule = float,class:^(kitty)$,title:^(kitty)$
-
+windowrule = opacity 1.0 1.0 1.0, title:(.*)(- Youtube)
 # Ignore maximize requests from apps. You'll probably like this.
 windowrule = suppressevent maximize, class:.*
 


### PR DESCRIPTION
Normal browser windows are still slightly translucent, youtube, however will now be completely opaque to make videos not suck