### PR TITLE
Fix windowrule for youtube opacity

### DIFF
--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -290,7 +290,7 @@ bindl = , XF86AudioPrev, exec, playerctl previous
 
 # Example windowrule
 # windowrule = float,class:^(kitty)$,title:^(kitty)$
-windowrule = opacity 1.0 1.0 1.0, title:.*(- YouTube).*
+windowrule = opacity 1.0 override, title:.*(- YouTube).*
 # Ignore maximize requests from apps. You'll probably like this.
 windowrule = suppressevent maximize, class:.*
 


### PR DESCRIPTION
Forgot to add the `override` keyword for the Youtube windowrule